### PR TITLE
fix: use Ubuntu-compatible Node shebang

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,6 +66,8 @@
     "access": "public"
   },
   "release": {
-    "branches": ["trunk"]
+    "branches": [
+      "trunk"
+    ]
   }
 }

--- a/src/cli.js
+++ b/src/cli.js
@@ -1,4 +1,5 @@
-#!/usr/bin/env node --no-warnings --experimental-modules --experimental-json-modules
+#!/bin/sh
+':' //; exec node --no-warnings --experimental-modules --experimental-json-modules "$0" "$@"
 
 const log = require("./util/log.js");
 


### PR DESCRIPTION
Fixes #1 

## Issue
Passing Node options on the shebang line works on Mac but not on Linux.

## Solution
Try an alternative shebang syntax

## Testing
After installing this package in a project or globally with `npm install -g`, verify that commands such as `migrator report` and `migrator migrate` work. The `MONGO_URL` environment variable must be set.