### PR TITLE
fix: fix undefined variable in namespace error msg

### DIFF
--- a/src/util/loadConfig.js
+++ b/src/util/loadConfig.js
@@ -57,7 +57,7 @@ async function loadConfig(configFilePath, { log = () => {} } = {}) {
 
     const trackInfo = packageMigrationConfig.tracks.find((packageTrack) => packageTrack.namespace === namespace);
     if (!trackInfo) {
-      log(`Cannot find migration namespace ${namespace} defined in ${fullTrackMigrationsFilePath}`, "error");
+      log(`Cannot find migration namespace ${namespace} defined in ${importPath}`, "error");
       return null;
     }
 


### PR DESCRIPTION
Fixes this error:

```
Attempting to find and load all listed tracks...
ReferenceError: fullTrackMigrationsFilePath is not defined
    at loadConfig (/Users/ek/Projects/reaction/reaction-utils/api-migrations/node_modules/@reactioncommerce/migrator/src/util/loadConfig.js:60:70)
    at async loadAndCheckConfig (/Users/ek/Projects/reaction/reaction-utils/api-migrations/node_modules/@reactioncommerce/migrator/src/util/loadAndCheckConfig.js:20:18)
    at async Command.<anonymous> 
```