### PR TITLE
feat(mongo): Don't fail if can't parse url

### DIFF
--- a/src/commands/migrate.js
+++ b/src/commands/migrate.js
@@ -45,7 +45,8 @@ function register(program) {
         parsedUrl.username = "USER";
         parsedUrl.password = "PASS";
       } catch (error) {
-        log("Error parsing URL", error);
+        log(error.stack || error, "error");
+        process.exit(1);
       }
 
 

--- a/src/commands/migrate.js
+++ b/src/commands/migrate.js
@@ -39,10 +39,16 @@ function register(program) {
         process.exit(0);
       }
 
-      let parsedUrl = new URL(MONGO_URL);
-      parsedUrl.username = "USER";
-      parsedUrl.password = "PASS";
-      log(`MongoDB URL: ${parsedUrl.href}\n`);
+      try {
+        // eslint-disable-next-line node/no-unsupported-features/node-builtins
+        const parsedUrl = new URL(MONGO_URL);
+        parsedUrl.username = "USER";
+        parsedUrl.password = "PASS";
+        log(`MongoDB URL: ${parsedUrl.href}\n`);
+      } catch (error) {
+        log("Error parsing URL, not logging to console");
+      }
+
 
       if (!options.yes) {
         const { shouldContinue } = await inquirer.prompt([

--- a/src/commands/migrate.js
+++ b/src/commands/migrate.js
@@ -44,9 +44,8 @@ function register(program) {
         const parsedUrl = new URL(MONGO_URL);
         parsedUrl.username = "USER";
         parsedUrl.password = "PASS";
-        log(`MongoDB URL: ${parsedUrl.href}\n`);
       } catch (error) {
-        log("Error parsing URL, not logging to console");
+        log("Error parsing URL", error);
       }
 
 

--- a/src/commands/migrate.js
+++ b/src/commands/migrate.js
@@ -46,7 +46,6 @@ function register(program) {
         parsedUrl.password = "PASS";
       } catch (error) {
         log(error.stack || error, "error");
-        process.exit(1);
       }
 
 


### PR DESCRIPTION
The `URL` lib chokes on replica set URls so if you can't parse it, don't crash and don't barf it out to the console