### PR TITLE
fix: lock mongodb version at 3.6.2 due to 3.6.3 issues

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2664,9 +2664,9 @@
       }
     },
     "bson": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-1.1.3.tgz",
-      "integrity": "sha512-TdiJxMVnodVS7r0BdL42y/pqC9cL2iKynVwA0Ho3qbsQYr428veL3l7BQyuqiw+Q5SqqoT0m4srSY/BlZ9AxXg=="
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-1.1.5.tgz",
+      "integrity": "sha512-kDuEzldR21lHciPQAIulLs1LZlCXdLziXI6Mb/TDkwXhb//UORJNPXgcRs2CuO4H0DcMkpfT3/ySsP3unoZjBg=="
     },
     "btoa-lite": {
       "version": "1.0.0",
@@ -7498,12 +7498,12 @@
       "dev": true
     },
     "mongodb": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.5.2.tgz",
-      "integrity": "sha512-Lxt4th2tK2MxmkDBR5cMik+xEnkvhwg0BC5kGcHm9RBwaNEsrIryvV5istGXOHbnif5KslMpY1FbX6YbGJ/Trg==",
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.6.2.tgz",
+      "integrity": "sha512-sSZOb04w3HcnrrXC82NEh/YGCmBuRgR+C1hZgmmv4L6dBz4BkRse6Y8/q/neXer9i95fKUBbFi4KgeceXmbsOA==",
       "requires": {
-        "bl": "^2.2.0",
-        "bson": "^1.1.1",
+        "bl": "^2.2.1",
+        "bson": "^1.1.4",
         "denque": "^1.4.1",
         "require_optional": "^1.0.1",
         "safe-buffer": "^5.1.2",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "commander": "^2.20.0",
     "envalid": "^6.0.1",
     "inquirer": "^6.5.0",
-    "mongodb": "^3.5.2",
+    "mongodb": "3.6.2",
     "pretty-ms": "^5.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
This PR locks mongodb at versions `3.6.2` for now, as mongodb v3.6.3 is causing issues with our `api-migrations` package.

I've left comments in a couple mongodb JIRA tickets related to these issues, as others have seen them as well:

https://jira.mongodb.org/projects/NODE-2878
https://jira.mongodb.org/browse/NODE-2966

Once those issues are resolved we can unlock for future updates.